### PR TITLE
Add `@docusaurus/plugin-content-docs` as dependency

### DIFF
--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -47,6 +47,7 @@
   "dependencies": {
     "@docusaurus/types": "2.0.0-beta.14",
     "@docusaurus/utils": "2.0.0-beta.14",
+    "@docusaurus/plugin-content-docs": "2.0.0-beta.14",
     "@vscode/codicons": "^0.0.27",
     "marked": "^3.0.8",
     "typedoc": "^0.22.10"


### PR DESCRIPTION
Fix this error:
```
> graphql@16.2.0 start
> DOCUSAURUS_GENERATED_FILES_DIR_NAME="$(pwd)/.docusaurus" docusaurus start ./website

[INFO] Starting the development server...
[ERROR] Error: Cannot find module '@docusaurus/plugin-content-docs/lib/constants'
Require stack:
- /Users/ivang/dev/graphql-js/node_modules/docusaurus-plugin-typedoc-api/lib/index.js
- /Users/ivang/dev/graphql-js/node_modules/@docusaurus/core/lib/server/plugins/init.js
- /Users/ivang/dev/graphql-js/node_modules/@docusaurus/core/lib/server/plugins/index.js
- /Users/ivang/dev/graphql-js/node_modules/@docusaurus/core/lib/server/index.js
- /Users/ivang/dev/graphql-js/node_modules/@docusaurus/core/lib/commands/build.js
- /Users/ivang/dev/graphql-js/node_modules/@docusaurus/core/lib/index.js
- /Users/ivang/dev/graphql-js/node_modules/@docusaurus/core/bin/docusaurus.js
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:933:15)
    at Function.Module._load (node:internal/modules/cjs/loader:778:27)
    at Module.require (node:internal/modules/cjs/loader:999:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (/Users/ivang/dev/graphql-js/node_modules/docusaurus-plugin-typedoc-api/lib/index.js:13:19)
    at Module._compile (node:internal/modules/cjs/loader:1095:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1147:10)
    at Module.load (node:internal/modules/cjs/loader:975:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Module.require (node:internal/modules/cjs/loader:999:19)
    at module.exports (/Users/ivang/dev/graphql-js/node_modules/import-fresh/index.js:32:59)
    at normalizePluginConfig (/Users/ivang/dev/graphql-js/node_modules/@docusaurus/core/lib/server/plugins/init.js:46:61)
    at /Users/ivang/dev/graphql-js/node_modules/@docusaurus/core/lib/server/plugins/init.js:138:40
    at Array.map (<anonymous>)
    at initPlugins (/Users/ivang/dev/graphql-js/node_modules/@docusaurus/core/lib/server/plugins/init.js:134:10)
    at loadPlugins (/Users/ivang/dev/graphql-js/node_modules/@docusaurus/core/lib/server/plugins/index.js:55:40)
```